### PR TITLE
fix: 🐛 firebase init でデプロイ対象のディレクトリとしてbuild/webを入力

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "public",
+    "public": "build/web",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
firebase initコマンドでfirebase hostingの設定をする時に、デフォルトのpublicディレクトリから変更する必要があります。
デフォルトのままだと、publc/index.htmlがデプロイされます。
flutterでbuildしたファイルは、build/webに作成されます。
このPRは無視して（マージしないで）、自分の環境でもう一度firebase initを実行したあとにこのPRと同じ状態になればデプロイも成功すると思います。